### PR TITLE
Bug fix 2909 with unit test

### DIFF
--- a/Microsoft.OData/src/AggregationTestProject/ApplyParserTests.cs
+++ b/Microsoft.OData/src/AggregationTestProject/ApplyParserTests.cs
@@ -408,5 +408,25 @@ namespace AggregationTestProject
                  });
             "Then an OData exception is thrown".Then(() => exception.Should().BeOfType<Microsoft.OData.Core.ODataException>());
         }
+
+        [Scenario]
+        [InlineData("$apply=filter(Timestamp gt cast(2014-11-25T12:39:05Z, Edm.DateTimeOffset))")]
+        public void CastingDoesNotRequireSpace(string query)
+        {
+            var model =
+                Common.TestModelBuilder.CreateModel(new Type[] { typeof(Category), typeof(Product), typeof(Sales) });
+            IEdmType edmType = model.FindDeclaredType(typeof(Sales).FullName);
+            var config = new ODataUriParserConfiguration(model);
+            var result = default(ApplyClause);
+
+            "Given a query to parse {0}".Given(() => { });
+            "When I Try to parse".When(
+                () =>
+                    {
+                        result = ApplyParser.ParseApplyImplementation(query, config, edmType, null);
+                    });
+            "Then we should have one transformation".Then(() => result.Transformations.Count.Should().Be(1));
+            "And the transformation is filter".And(() => result.Transformations.First().Item2.Should().BeOfType<ApplyFilterClause>());
+        }
     }
 }

--- a/Microsoft.OData/src/AggregationTestProject/Common/Entities.cs
+++ b/Microsoft.OData/src/AggregationTestProject/Common/Entities.cs
@@ -17,6 +17,8 @@ namespace AggregationTestProject.Common
 
         public int Time { get; set; }
 
+        public DateTimeOffset Timestamp { get; set; }
+
     }
 
     public class Product

--- a/Microsoft.OData/src/AggregationTestProject/Common/TestModelBuilder.cs
+++ b/Microsoft.OData/src/AggregationTestProject/Common/TestModelBuilder.cs
@@ -35,7 +35,7 @@ namespace AggregationTestProject.Common
                 foreach (var pi in clrType.GetProperties())
                 {
                     
-                    if (pi.PropertyType.IsPrimitive || pi.PropertyType.FullName == "System.String" || pi.PropertyType.IsEnum)
+                    if (pi.PropertyType.IsValueType || pi.PropertyType.FullName == "System.String" || pi.PropertyType.IsEnum)
                     {
                         edmType.AddStructuralProperty(
                             pi.Name,

--- a/Microsoft.OData/src/OData/Aggregation/ApplyParser.cs
+++ b/Microsoft.OData/src/OData/Aggregation/ApplyParser.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OData.Core.Aggregation
         /// <returns></returns>
         private static ApplyFilterClause ParseFilter(ApplyClause apply, string query, ODataUriParserConfiguration oDataUriParserConfiguration, IEdmType edmType, IEdmNavigationSource edmNavigationSource)
         {
-            query = IsolateQuery(query, UriQueryConstants.FilterTransformation).Trim('(',')');
+            query = IsolateQuery(query, UriQueryConstants.FilterTransformation);
             return new ApplyFilterClause()
             {
                 Apply = apply,


### PR DESCRIPTION
Fixing VSO Bug#2909 Space required to Close Paren for Query to be successful. Issue caused by Trim method removing ')' from cast expression.
